### PR TITLE
Fix broken shebang and Redis usage

### DIFF
--- a/bin/build-cfssl
+++ b/bin/build-cfssl
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -e +x
+#!/usr/bin/env bash
+
+set -ex
 
 ### Requirements
 

--- a/lib/cfssl-trust-store-preamble.rb
+++ b/lib/cfssl-trust-store-preamble.rb
@@ -4,4 +4,4 @@ CFSSL_TRUST_URL = "https://github.com/cloudflare/cfssl_trust"
 CFSSL_TRUST_DIR = File.expand_path(File.dirname(__FILE__) + "/../vendor/cfssl_trust.git")
 TRUST_FILENAMES = %w[ca-bundle.crt ca-bundle.crt.metadata int-bundle.crt]
 
-TRUST_STORE = Redis.connect url: ENV["REDIS_URL"]
+TRUST_STORE = Redis.new(url: ENV["REDIS_URL"])


### PR DESCRIPTION
Most OS's only support a single argument for the shebang. So we'll use `set` to set the options we want.

Also, Redis dropped `Redis::connect` in the 4.x series. This fixes that. However, I still expect these scripts too be broken b/c they rely on REALLY OLD Golang that doesn't really work (no modules), and none of this code has been actively maintained in over 4 years. 🤷
